### PR TITLE
fix protobuf cmake build

### DIFF
--- a/registry/modules/protobuf/25.3.arenastring/patches/arenastring.patch
+++ b/registry/modules/protobuf/25.3.arenastring/patches/arenastring.patch
@@ -4093,6 +4093,42 @@ index d4af7dfec..24a5a670f 100644
 +
  }
  
+diff --git a/src/file_lists.cmake b/src/file_lists.cmake
+index d320be43a..310d217d6 100644
+--- a/src/file_lists.cmake
++++ b/src/file_lists.cmake
+@@ -26,6 +26,7 @@ set(libprotobuf_srcs
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/arena.cc
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/arena_align.cc
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/arenastring.cc
++  ${protobuf_SOURCE_DIR}/src/google/protobuf/arenastring_impl.cc
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/arenaz_sampler.cc
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/importer.cc
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/parser.cc
+@@ -108,6 +109,7 @@ set(libprotobuf_hdrs
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/arena_allocation_policy.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/arena_cleanup.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/arenastring.h
++  ${protobuf_SOURCE_DIR}/src/google/protobuf/arenastring_impl.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/arenaz_sampler.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/importer.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/parser.h
+@@ -210,6 +212,7 @@ set(libprotobuf_lite_srcs
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/arena.cc
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/arena_align.cc
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/arenastring.cc
++  ${protobuf_SOURCE_DIR}/src/google/protobuf/arenastring_impl.cc
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/arenaz_sampler.cc
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/extension_set.cc
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/generated_enum_util.cc
+@@ -241,6 +244,7 @@ set(libprotobuf_lite_hdrs
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/arena_allocation_policy.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/arena_cleanup.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/arenastring.h
++  ${protobuf_SOURCE_DIR}/src/google/protobuf/arenastring_impl.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/arenaz_sampler.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/endian.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/explicitly_constructed.h
 diff --git a/src/google/protobuf/BUILD.bazel b/src/google/protobuf/BUILD.bazel
 index 8961ca6af..ad1513689 100644
 --- a/src/google/protobuf/BUILD.bazel


### PR DESCRIPTION
There'll be problem compiling with CMake after patching `arenastring.patch`