### PR TITLE
[docs] Format a code snippet.

### DIFF
--- a/docs/future.en.md
+++ b/docs/future.en.md
@@ -20,48 +20,50 @@ using ::babylon::Future;
 using ::babylon::Promise;
 
 {
-	Promise<int> promise;
+    Promise<int> promise;
     auto future = promise.get_future();
-    ::std::thread thread([&] () {
+    ::std::thread thread([&]() {
         // Perform some asynchronous operations
         ...
-		// Set the final value
+        // Set the final value
         promise.set_value(10086);
     });
-    future.get(); // Waits for set_value, result == 10086
+    future.get();  // Waits for set_value, result == 10086
 }
 
 {
     // Example using an XSchedInterface coroutine mechanism for synchronization
-	Promise<int, XSchedInterface> promise;
+    Promise<int, XSchedInterface> promise;
     auto future = promise.get_future();
-    XThread thread([&] () {
+    XThread thread([&]() {
         // Perform some asynchronous operations
         ...
-		// Set the final value
+        // Set the final value
         promise.set_value(10086);
     });
-    future.get(); // Waits for set_value (using XSchedInterface for coroutine synchronization without occupying pthread workers), result == 10086
+    future.get();  // Waits for set_value (using XSchedInterface for coroutine
+                   // synchronization without occupying pthread workers), result
+                   // == 10086
 }
 
 {
-	Promise<int> promise;
+    Promise<int> promise;
     auto future = promise.get_future();
-	// Move-capture promise to avoid destruction out of scope
-    ::std::thread thread([promise = ::std::move(promise)] () mutable {
+    // Move-capture promise to avoid destruction out of scope
+    ::std::thread thread([promise = ::std::move(promise)]() mutable {
         // Perform some asynchronous operations
         ...
-		// Set the final value
+        // Set the final value
         promise.set_value(10086);
     });
     Promise<int> promise2;
-	auto future2 = promise2.get_future();
-    future.on_finish([promise2 = ::std::move(promise2)] (int&& value) {
- 		// Called by set_value, with value == 10086
-		promise2.set_value(value + 10010);
-	});
-	// After on_finish, future is no longer available, cannot be ready or get
-    future2.get(); // Waits for set_value, result == 20096
+    auto future2 = promise2.get_future();
+    future.on_finish([promise2 = ::std::move(promise2)](int&& value) {
+        // Called by set_value, with value == 10086
+        promise2.set_value(value + 10010);
+    });
+    // After on_finish, future is no longer available, cannot be ready or get
+    future2.get();  // Waits for set_value, result == 20096
 }
 
 // For further details, see comments and test cases

--- a/docs/future.zh-cn.md
+++ b/docs/future.zh-cn.md
@@ -26,8 +26,8 @@ using ::babylon::Promise;
     ::std::thread thread([&]() {
         // 异步做一些事情
         ...
-            // 最终赋值
-            promise.set_value(10086);
+        // 最终赋值
+        promise.set_value(10086);
     });
     future.get();  // 等待set_value，结果 == 10086
 }
@@ -39,8 +39,8 @@ using ::babylon::Promise;
     XThread thread([&]() {
         // 异步做一些事情
         ...
-            // 最终赋值
-            promise.set_value(10086);
+        // 最终赋值
+        promise.set_value(10086);
     });
     future.get();  // 等待set_value（使用XSchedInterface协程同步，不占用pthread
                    // worker），结果 == 10086
@@ -53,8 +53,8 @@ using ::babylon::Promise;
     ::std::thread thread([promise = ::std::move(promise)]() mutable {
         // 异步做一些事情
         ...
-            // 最终赋值
-            promise.set_value(10086);
+        // 最终赋值
+        promise.set_value(10086);
     });
     Promise<int> promise2;
     auto future2 = promise2.get_future();

--- a/docs/future.zh-cn.md
+++ b/docs/future.zh-cn.md
@@ -26,8 +26,8 @@ using ::babylon::Promise;
     ::std::thread thread([&]() {
         // 异步做一些事情
         ...
-        // 最终赋值
-        promise.set_value(10086);
+            // 最终赋值
+            promise.set_value(10086);
     });
     future.get();  // 等待set_value，结果 == 10086
 }
@@ -39,10 +39,11 @@ using ::babylon::Promise;
     XThread thread([&]() {
         // 异步做一些事情
         ...
-        // 最终赋值
-        promise.set_value(10086);
+            // 最终赋值
+            promise.set_value(10086);
     });
-    future.get();  // 等待set_value（使用XSchedInterface协程同步，不占用pthread worker），结果 == 10086
+    future.get();  // 等待set_value（使用XSchedInterface协程同步，不占用pthread
+                   // worker），结果 == 10086
 }
 
 {
@@ -52,8 +53,8 @@ using ::babylon::Promise;
     ::std::thread thread([promise = ::std::move(promise)]() mutable {
         // 异步做一些事情
         ...
-        // 最终赋值
-        promise.set_value(10086);
+            // 最终赋值
+            promise.set_value(10086);
     });
     Promise<int> promise2;
     auto future2 = promise2.get_future();

--- a/docs/future.zh-cn.md
+++ b/docs/future.zh-cn.md
@@ -21,48 +21,48 @@ using ::babylon::Future;
 using ::babylon::Promise;
 
 {
-	Promise<int> promise;
+    Promise<int> promise;
     auto future = promise.get_future();
-    ::std::thread thread([&] () {
+    ::std::thread thread([&]() {
         // 异步做一些事情
         ...
-		// 最终赋值
+        // 最终赋值
         promise.set_value(10086);
     });
-    future.get(); // 等待set_value，结果 == 10086
+    future.get();  // 等待set_value，结果 == 10086
 }
- 
+
 {
     // 例如有一种XSchedInterface的协程机制，使用对应的机制来同步
-	Promise<int, XSchedInterface> promise;
+    Promise<int, XSchedInterface> promise;
     auto future = promise.get_future();
-    XThread thread([&] () {
+    XThread thread([&]() {
         // 异步做一些事情
         ...
-		// 最终赋值
+        // 最终赋值
         promise.set_value(10086);
     });
-    future.get(); // 等待set_value（使用XSchedInterface协程同步，不占用pthread worker），结果 == 10086
+    future.get();  // 等待set_value（使用XSchedInterface协程同步，不占用pthread worker），结果 == 10086
 }
- 
+
 {
-	Promise<int> promise;
+    Promise<int> promise;
     auto future = promise.get_future();
-	// 移动捕获promise，避免出作用域销毁
-    ::std::thread thread([promise = ::std::move(promise)] () mutable {
+    // 移动捕获promise，避免出作用域销毁
+    ::std::thread thread([promise = ::std::move(promise)]() mutable {
         // 异步做一些事情
         ...
-		// 最终赋值
+        // 最终赋值
         promise.set_value(10086);
     });
     Promise<int> promise2;
-	auto future2 = promise2.get_future();
-    future.on_finish([promise2 = ::std::move(promise2)] (int&& value) {
- 		// 由set_value调用，传入value == 10086
-		promise2.set_value(value + 10010);
-	});
-	// on_finish之后future不再可用，无法ready或者get
-    future2.get(); // 等待set_value，结果 == 20096
+    auto future2 = promise2.get_future();
+    future.on_finish([promise2 = ::std::move(promise2)](int&& value) {
+        // 由set_value调用，传入value == 10086
+        promise2.set_value(value + 10010);
+    });
+    // on_finish之后future不再可用，无法ready或者get
+    future2.get();  // 等待set_value，结果 == 20096
 }
 
 // 更说明见注释


### PR DESCRIPTION
The code snippet in this patch uses a mix of tabs and spaces for indentation, resulting in a weird appearance. This update fixes it with clang-format, hopefully improving its appearance.