### PR TITLE
Support leaky CompactEnumerableThreadLocal and fix counter crash at exit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+cmake-build-*

--- a/example/use-counter-with-bvar/recorder.h
+++ b/example/use-counter-with-bvar/recorder.h
@@ -153,7 +153,7 @@ class BvarIntRecorder : public ::bvar::Variable {
   sampler_type* _sampler {nullptr};
 };
 
-// ::bvar::detail::IntRecorder的替换实现
+// ::bvar::detail::Percentile的替换实现
 class BvarPercentile {
  public:
   // 支持加入Window所需的类型定义

--- a/src/babylon/BUILD
+++ b/src/babylon/BUILD
@@ -174,6 +174,7 @@ cc_library(
   includes = ['//src'],
   strip_include_prefix = '//src',
   deps = [
+    '@com_google_absl//absl/debugging:leak_check',
     ':environment',
   ],
 )

--- a/src/babylon/concurrent/BUILD
+++ b/src/babylon/concurrent/BUILD
@@ -131,6 +131,7 @@ cc_library(
   includes = ['//src'],
   strip_include_prefix = '//src',
   deps = [
+    '//src/babylon:sanitizer_helper',
     ':id_allocator',
   ],
 )

--- a/src/babylon/concurrent/counter.h
+++ b/src/babylon/concurrent/counter.h
@@ -43,7 +43,7 @@ class ConcurrentAdder {
  private:
   inline void count(ssize_t value) noexcept;
 
-  CompactEnumerableThreadLocal<ssize_t, 64> _storage;
+  CompactEnumerableThreadLocal<ssize_t, 64, true> _storage;
 };
 
 // 高并发最大值计数器
@@ -85,7 +85,7 @@ class ConcurrentMaxer {
     ssize_t value;
   };
 
-  CompactEnumerableThreadLocal<Slot, 64> _storage;
+  CompactEnumerableThreadLocal<Slot, 64, true> _storage;
   size_t _version {0};
 };
 
@@ -123,7 +123,7 @@ class ConcurrentSummer {
   Summary value() const noexcept;
 
  private:
-  CompactEnumerableThreadLocal<Summary, 64> _storage;
+  CompactEnumerableThreadLocal<Summary, 64, true> _storage;
 };
 
 // 高并发采样计数器


### PR DESCRIPTION
Fix #89 .

1. CompactEnumerableThreadLocal支持不析构内部静态资源的模式（Leaky = true时，默认为false）。
2. counter使用CompactEnumerableThreadLocal的不析构模式，可以覆盖所有使用场景。