### PR TITLE
Fix  ConcurrentSampler carsh at exit and Revert #91

### DIFF
--- a/src/babylon/concurrent/counter.cpp
+++ b/src/babylon/concurrent/counter.cpp
@@ -53,7 +53,7 @@ size_t ConcurrentSampler::bucket_capacity(size_t index) const noexcept {
   return _bucket_capacity[index];
 }
 
-ConcurrentSampler& ConcurrentSampler::operator<<(uint64_t value) noexcept {
+ConcurrentSampler& ConcurrentSampler::operator<<(uint32_t value) noexcept {
   auto bucket = prepare_sample_bucket(value);
   // record_num只有本计数线程会写入，无需特殊同步
   auto record_num = bucket->record_num.load(::std::memory_order_relaxed);
@@ -79,7 +79,7 @@ void ConcurrentSampler::reset() noexcept {
 }
 
 ConcurrentSampler::SampleBucket* ConcurrentSampler::prepare_sample_bucket(
-    uint64_t value) noexcept {
+    uint32_t value) noexcept {
   auto index = bucket_index(value);
   auto& local = _storage.local();
   // 检测是否开启了新版本
@@ -97,7 +97,7 @@ ConcurrentSampler::SampleBucket* ConcurrentSampler::prepare_sample_bucket(
     // 桶未创建，或者容量需要调整
     if (bucket == nullptr || bucket->capacity != _bucket_capacity[index]) {
       size_t capacity = _bucket_capacity[index];
-      size_t allocate_size = sizeof(SampleBucket) + sizeof(uint64_t) * capacity;
+      size_t allocate_size = sizeof(SampleBucket) + sizeof(uint32_t) * capacity;
       allocate_size = (allocate_size + BABYLON_CACHELINE_SIZE - 1) &
                       static_cast<size_t>(-BABYLON_CACHELINE_SIZE);
       if (bucket == nullptr || allocate_size != bucket->allocate_size) {

--- a/src/babylon/concurrent/counter.h
+++ b/src/babylon/concurrent/counter.h
@@ -308,7 +308,7 @@ class ConcurrentSampler {
 
   SampleBucket* prepare_sample_bucket(uint64_t value) noexcept;
 
-  EnumerableThreadLocal<Sample> _storage;
+  EnumerableThreadLocal<Sample, true> _storage;
   uint8_t _bucket_capacity[32] = {30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
                                   30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
                                   30, 30, 30, 30, 30, 30, 30, 30, 30, 30};

--- a/src/babylon/concurrent/counter.h
+++ b/src/babylon/concurrent/counter.h
@@ -260,7 +260,7 @@ class ConcurrentSampler {
   ~ConcurrentSampler() noexcept = default;
 
   // 计算目标值所在的分桶
-  inline static size_t bucket_index(uint64_t value) noexcept;
+  inline static size_t bucket_index(uint32_t value) noexcept;
 
   // 设置目标分桶的预期容量，支持运行中动态修改
   // 修改会在下一轮reset之后生效
@@ -268,7 +268,7 @@ class ConcurrentSampler {
   size_t bucket_capacity(size_t index) const noexcept;
 
   // 计数操作
-  ConcurrentSampler& operator<<(uint64_t value) noexcept;
+  ConcurrentSampler& operator<<(uint32_t value) noexcept;
 
   // 遍历收集各个线程的采样桶，并调用
   // C(size_t bucket_index, const SampleBucket&)
@@ -288,7 +288,7 @@ class ConcurrentSampler {
     // 采样前数据总量，超出capacity之后只保留capacity
     ::std::atomic<uint32_t> record_num;
     // 实际采样值
-    uint64_t data[0];
+    uint32_t data[0];
   };
 
  private:
@@ -297,16 +297,17 @@ class ConcurrentSampler {
 
     ::std::atomic<uint32_t> version {0};
     ::std::atomic<uint32_t> non_empty_bucket_mask {0};
-    SampleBucket* buckets[32] = {
+    SampleBucket* buckets[31] = {
         nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
         nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
         nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-        nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+        nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
+    };
   };
 
   inline static uint16_t xorshift128_rand() noexcept;
 
-  SampleBucket* prepare_sample_bucket(uint64_t value) noexcept;
+  SampleBucket* prepare_sample_bucket(uint32_t value) noexcept;
 
   EnumerableThreadLocal<Sample, true> _storage;
   uint8_t _bucket_capacity[32] = {30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
@@ -348,27 +349,17 @@ ConcurrentSummer::operator<<(Summary summary) noexcept {
 ////////////////////////////////////////////////////////////////////////////////
 // ConcurrentSampler begin
 inline ABSL_ATTRIBUTE_ALWAYS_INLINE size_t
-ConcurrentSampler::bucket_index(uint64_t value) noexcept {
+ConcurrentSampler::bucket_index(uint32_t value) noexcept {
   // [0, 2) => 0
   // [2, 2^31) => log2(n)
   // [2^31, 2^32) => 30
-  // [2^32, 2^64) => 31
-
-  // 63 - 前导零个数（0当做1处理，避免__builtin_clzll异常），得到对数值。
-  int64_t log2n = 63 - __builtin_clzll(value | 1);
-
-  // >= 30 => ~0
-  // < 30  =>  0
-  uint64_t mask30 = -static_cast<uint64_t>(log2n > 29);
-  // >= 32 => ~0
-  // < 32  =>  0
-  uint64_t mask32 = -static_cast<uint64_t>(log2n > 31);
-
-  // log_val < 30       => log2n
-  // 30 <= log_val < 32 => 30
-  // log_val >= 32      => 31
-  uint64_t adjusted = 30 + (mask32 & 1);
-  return (mask30 & adjusted) | (~mask30 & static_cast<uint64_t>(log2n));
+  value &= 0x7FFFFFFF;
+  value >>= 1;
+  if (ABSL_PREDICT_FALSE(value == 0)) {
+    return 0;
+  } else {
+    return 32 - static_cast<size_t>(__builtin_clz(value));
+  }
 }
 
 template <typename C>

--- a/src/babylon/concurrent/id_allocator.hpp
+++ b/src/babylon/concurrent/id_allocator.hpp
@@ -147,8 +147,8 @@ struct IdAllocatorFotType {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wunknown-warning-option"
-    BABYLON_LEAK_CHECK_DISABLER;
-    static auto object = new IdAllocator<uint32_t>();
+    BABYLON_LEAK_CHECK_DISABLER();
+    static auto object = new IdAllocator<uint16_t>();
 #pragma GCC diagnostic pop
     return *object;
   }
@@ -184,6 +184,7 @@ VersionedValue<uint16_t> ThreadIdImpl<Leaky>::current_thread_id() noexcept {
 #pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wunknown-warning-option"
 #pragma GCC diagnostic ignored "-Wexit-time-destructors"
+  BABYLON_LEAK_CHECK_DISABLER(Leaky);
   thread_local ThreadIdImpl id(
       concurrent_id_allocator::IdAllocatorFotType<T, Leaky>::instance());
 #pragma GCC diagnostic pop

--- a/src/babylon/concurrent/thread_local.h
+++ b/src/babylon/concurrent/thread_local.h
@@ -13,7 +13,7 @@ BABYLON_NAMESPACE_BEGIN
 template <typename T, bool Leaky = false>
 class EnumerableThreadLocal {
   using ThreadIdType =
-      typename std::conditional<Leaky, LeakyThreadId, ThreadId>::type;
+      typename ::std::conditional<Leaky, LeakyThreadId, ThreadId>::type;
 
  public:
   // 可默认构造，可以移动，不能拷贝
@@ -123,7 +123,7 @@ class CompactEnumerableThreadLocal {
   // 获得线程局部存储
   template <bool L = Leaky>
   inline typename ::std::enable_if<L, T&>::type local() {
-    BABYLON_LEAK_CHECK_DISABLER;
+    BABYLON_LEAK_CHECK_DISABLER();
     return _storage->local().value[_cacheline_offset];
   }
   template <bool L = Leaky>
@@ -181,12 +181,12 @@ class CompactEnumerableThreadLocal {
   struct alignas(BABYLON_CACHELINE_SIZE) CacheLine {
     T value[NUM_PER_CACHELINE];
   };
-  using Storage = EnumerableThreadLocal<CacheLine>;
+  using Storage = EnumerableThreadLocal<CacheLine, Leaky>;
   using StorageVector = ConcurrentVector<Storage, 128>;
 
   template <bool L = Leaky>
   static typename ::std::enable_if<L, uint32_t>::type allocate_id() noexcept {
-    BABYLON_LEAK_CHECK_DISABLER;
+    BABYLON_LEAK_CHECK_DISABLER();
     return id_allocator().allocate().value;
   }
   template <bool L = Leaky>
@@ -200,7 +200,7 @@ class CompactEnumerableThreadLocal {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wunknown-warning-option"
-    BABYLON_LEAK_CHECK_DISABLER;
+    BABYLON_LEAK_CHECK_DISABLER();
     static auto allocator = new IdAllocator<uint32_t>();
 #pragma GCC diagnostic pop
     return *allocator;
@@ -223,7 +223,7 @@ class CompactEnumerableThreadLocal {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wunknown-warning-option"
-    BABYLON_LEAK_CHECK_DISABLER;
+    BABYLON_LEAK_CHECK_DISABLER();
     static auto storage_vector = new StorageVector();
 #pragma GCC diagnostic pop
     return storage_vector->ensure(slot_index);

--- a/src/babylon/sanitizer_helper.h
+++ b/src/babylon/sanitizer_helper.h
@@ -92,22 +92,32 @@ struct SanitizerHelper {
 #ifdef BABYLON_HAVE_LEAK_SANITIZER
 class LeakCheckDisabler {
  public:
-  LeakCheckDisabler() {
+  LeakCheckDisabler() : _disable_leak_check(true) {
     __lsan_disable();
+  }
+  LeakCheckDisabler(bool disable_leak_check)
+      : _disable_leak_check(disable_leak_check) {
+    if (_disable_leak_check) {
+      __lsan_disable();
+    }
   }
   LeakCheckDisabler(const LeakCheckDisabler&) = delete;
   LeakCheckDisabler& operator=(const LeakCheckDisabler&) = delete;
   ~LeakCheckDisabler() {
-    __lsan_enable();
+    if (_disable_leak_check) {
+      __lsan_enable();
+    }
   }
+ private:
+  bool _disable_leak_check;
 };
 
-#define BABYLON_LEAK_CHECK_DISABLER        \
-  LeakCheckDisabler __disabler_##__LINE__; \
+#define BABYLON_LEAK_CHECK_DISABLER(...)                \
+  LeakCheckDisabler __disabler_##__LINE__{__VA_ARGS__}; \
   ((void)0)
 
 #else
-#define BABYLON_LEAK_CHECK_DISABLER ((void)0)
+#define BABYLON_LEAK_CHECK_DISABLER(...) ((void)0)
 #endif // BABYLON_HAVE_LEAK_SANITIZER
 
 BABYLON_NAMESPACE_END

--- a/test/concurrent/test_counter.cpp
+++ b/test/concurrent/test_counter.cpp
@@ -273,10 +273,8 @@ TEST(concurrent_summary, caculate_right) {
 
 TEST(concurrent_sampler, collect_sample_from_multithread) {
   ConcurrentSampler sampler;
-  uint64_t val64 =
-      static_cast<uint64_t>(::std::numeric_limits<uint32_t>::max()) + 1;
   ::std::thread a([&] {
-    sampler << val64;
+    sampler << 1;
     sampler << 3;
   });
   ::std::thread b([&] {
@@ -292,7 +290,7 @@ TEST(concurrent_sampler, collect_sample_from_multithread) {
   c.join();
 
   size_t total_record_num = 0;
-  ::std::vector<uint64_t> result;
+  ::std::vector<uint32_t> result;
   sampler.for_each([&](size_t, const ConcurrentSampler::SampleBucket& bucket) {
     auto record_num = bucket.record_num.load(::std::memory_order_acquire);
     total_record_num += record_num;
@@ -302,7 +300,7 @@ TEST(concurrent_sampler, collect_sample_from_multithread) {
     }
   });
 
-  ::std::vector<uint64_t> expected = {3, 3, 5, 7, 9, val64};
+  ::std::vector<uint32_t> expected = {1, 3, 3, 5, 7, 9};
   ::std::sort(result.begin(), result.end());
   ASSERT_EQ(result.size(), total_record_num);
   ASSERT_EQ(expected, result);
@@ -315,7 +313,7 @@ TEST(concurrent_sampler, random_drop_sample_after_reach_capacity) {
   }
 
   size_t total_record_num = 0;
-  ::std::vector<uint64_t> result;
+  ::std::vector<uint32_t> result;
   sampler.for_each([&](size_t, const ConcurrentSampler::SampleBucket& bucket) {
     auto record_num = bucket.record_num.load(::std::memory_order_acquire);
     total_record_num += record_num;
@@ -339,7 +337,7 @@ TEST(concurrent_sampler, reset_drops_all) {
   sampler << 10086;
 
   size_t total_record_num = 0;
-  ::std::vector<uint64_t> result;
+  ::std::vector<uint32_t> result;
   sampler.for_each([&](size_t, const ConcurrentSampler::SampleBucket& bucket) {
     auto record_num = bucket.record_num.load(::std::memory_order_acquire);
     total_record_num += record_num;
@@ -364,7 +362,7 @@ TEST(concurrent_sampler, new_capacity_used_after_reset) {
 
   {
     size_t total_record_num = 0;
-    ::std::vector<uint64_t> result;
+    ::std::vector<uint32_t> result;
     sampler.for_each(
         [&](size_t, const ConcurrentSampler::SampleBucket& bucket) {
           auto record_num = bucket.record_num.load(::std::memory_order_acquire);
@@ -385,7 +383,7 @@ TEST(concurrent_sampler, new_capacity_used_after_reset) {
 
   {
     size_t total_record_num = 0;
-    ::std::vector<uint64_t> result;
+    ::std::vector<uint32_t> result;
     sampler.for_each(
         [&](size_t, const ConcurrentSampler::SampleBucket& bucket) {
           auto record_num = bucket.record_num.load(::std::memory_order_acquire);


### PR DESCRIPTION
1. ConcurrentSampler在程序退出时，还是会crash。原因是未使用Leaky模式的EnumerableThreadLocal。
2.  Revert #91 ，修复#106 的问题。