### PR TITLE
Make Summary 128-bit aligned within the cacheline

### DIFF
--- a/src/babylon/concurrent/counter.h
+++ b/src/babylon/concurrent/counter.h
@@ -208,7 +208,7 @@ using ConcurrentMiner = GenericsConcurrentMiner<ssize_t>;
 class ConcurrentSummer {
  public:
   // 计数结果二元组，总和&总量
-  struct Summary {
+  struct alignas(BABYLON_CACHELINE_SIZE) Summary {
     ssize_t sum;
     size_t num;
   };


### PR DESCRIPTION
ConcurrentSummer::Summary也有https://github.com/apache/brpc/issues/3091 一样的问题，形参内存可能没有对齐，不能满足128bit原子读写要求。

https://github.com/baidu/babylon/blob/c230b4ff3500080669109b77bedb5e2a72c220c7/src/babylon/concurrent/counter.h#L324-L341